### PR TITLE
Implement Command Pattern with SimpleExecutor for disk benchmark jobs 

### DIFF
--- a/app/src/main/java/edu/touro/mco152/bm/App.java
+++ b/app/src/main/java/edu/touro/mco152/bm/App.java
@@ -326,12 +326,9 @@ public class App {
     }
 
     /**
-     * INDUCED BUG for JUnit assignment: changed {@code * numOfMarks} to
-     * {@code + numOfMarks}.  This breaks the cross-check test in AppTest
-     * that verifies targetTxSizeKb() == numOfMarks * targetMarkSizeKb().
      */
     public static long targetTxSizeKb() {
-        return (long) blockSizeKb * numOfBlocks + numOfMarks;
+        return (long) blockSizeKb * numOfBlocks * numOfMarks;
     }
 
     public static void updateMetrics(DiskMark mark) {

--- a/app/src/main/java/edu/touro/mco152/bm/DiskMark.java
+++ b/app/src/main/java/edu/touro/mco152/bm/DiskMark.java
@@ -14,7 +14,7 @@ public class DiskMark {
     private double cumMin = 0;
     private double cumMax = 0;
     private double cumAvg = 0;
-    DiskMark(MarkType type) {
+    public DiskMark(MarkType type) {
         this.type = type;
     }
 
@@ -23,7 +23,7 @@ public class DiskMark {
         return "Mark(" + type + "): " + getMarkNum() + " bwMbSec: " + getBwMbSecAsString() + " avg: " + getAvgAsString();
     }
 
-    String getBwMbSecAsString() {
+    public String getBwMbSecAsString() {
         return df.format(getBwMbSec());
     }
 

--- a/app/src/main/java/edu/touro/mco152/bm/DiskWorker.java
+++ b/app/src/main/java/edu/touro/mco152/bm/DiskWorker.java
@@ -1,20 +1,14 @@
 package edu.touro.mco152.bm;
 
-import edu.touro.mco152.bm.persist.DiskRun;
-import edu.touro.mco152.bm.persist.EM;
+import edu.touro.mco152.bm.commands.BenchmarkExecutor;
+import edu.touro.mco152.bm.commands.ReadCommand;
+import edu.touro.mco152.bm.commands.SimpleExecutor;
+import edu.touro.mco152.bm.commands.WriteCommand;
 
-import jakarta.persistence.EntityManager;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static edu.touro.mco152.bm.App.*;
-import static edu.touro.mco152.bm.DiskMark.MarkType.READ;
-import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
 
 /**
  * Executes disk benchmarking on whatever thread the caller provides.
@@ -55,25 +49,6 @@ public class DiskWorker {
         ui.showMessage("num files: " + App.numOfMarks + ", num blks: " + App.numOfBlocks
                 + ", blk size (kb): " + App.blockSizeKb + ", blockSequence: " + App.blockSequence);
 
-        /*
-          init local vars that keep track of benchmarks, and a large read/write buffer
-         */
-        int wUnitsComplete = 0, rUnitsComplete = 0, unitsComplete;
-        int wUnitsTotal = App.writeTest ? numOfBlocks * numOfMarks : 0;
-        int rUnitsTotal = App.readTest ? numOfBlocks * numOfMarks : 0;
-        int unitsTotal = wUnitsTotal + rUnitsTotal;
-        float percentComplete;
-
-        int blockSize = blockSizeKb * KILOBYTE;
-        byte[] blockArr = new byte[blockSize];
-        for (int b = 0; b < blockArr.length; b++) {
-            if (b % 2 == 0) {
-                blockArr[b] = (byte) 0xFF;
-            }
-        }
-
-        DiskMark wMark, rMark;  // declare vars that will point to objects used to pass progress to UI
-
         if (App.autoReset) {
             App.resetTestData();
         }
@@ -81,105 +56,12 @@ public class DiskWorker {
         int startFileNum = App.nextMarkNumber;
         boolean success = true;
 
+        BenchmarkExecutor executor = new SimpleExecutor();
+
         if (App.writeTest) {
-            DiskRun run = new DiskRun(DiskRun.IOMode.WRITE, App.blockSequence);
-            run.setNumMarks(App.numOfMarks);
-            run.setNumBlocks(App.numOfBlocks);
-            run.setBlockSize(App.blockSizeKb);
-            run.setTxSize(App.targetTxSizeKb());
-            run.setDiskInfo(Util.getDiskInfo(dataDir));
-
-            // Tell logger and UI to display what we know so far about the Run
-            ui.showMessage("disk info: (" + run.getDiskInfo() + ")");
-
-            // Create a test data file using the default file system and config-specified location
-            if (!App.multiFile) {
-                testFile = new File(dataDir.getAbsolutePath() + File.separator + "testdata.jdm");
-            }
-
-            /*
-              Begin an outer loop for specified duration (number of 'marks') of benchmark,
-              that keeps writing data (in its own loop - for specified # of blocks). Each 'Mark' is timed
-              and is reported to the UI for display as each Mark completes.
-             */
-            for (int m = startFileNum; m < startFileNum + App.numOfMarks && !ui.isCancelled(); m++) {
-
-                if (App.multiFile) {
-                    testFile = new File(dataDir.getAbsolutePath()
-                            + File.separator + "testdata" + m + ".jdm");
-                }
-                wMark = new DiskMark(WRITE);    // starting to keep track of a new benchmark
-                wMark.setMarkNum(m);
-                long startTime = System.nanoTime();
-                long totalBytesWrittenInMark = 0;
-
-                String mode = App.writeSyncEnable ? "rwd" : "rw";
-
-                try {
-                    try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, mode)) {
-                        for (int b = 0; b < numOfBlocks; b++) {
-                            if (App.blockSequence == DiskRun.BlockSequence.RANDOM) {
-                                int rLoc = Util.randInt(0, numOfBlocks - 1);
-                                rAccFile.seek((long) rLoc * blockSize);
-                            } else {
-                                rAccFile.seek((long) b * blockSize);
-                            }
-                            rAccFile.write(blockArr, 0, blockSize);
-                            totalBytesWrittenInMark += blockSize;
-                            wUnitsComplete++;
-                            unitsComplete = rUnitsComplete + wUnitsComplete;
-                            percentComplete = (float) unitsComplete / (float) unitsTotal * 100f;
-
-                            /*
-                              Report to UI what percentage of the entire BM (#Marks * #Blocks) is done.
-                             */
-                            ui.updateProgress((int) percentComplete);
-                        }
-                    }
-                } catch (IOException ex) {
-                    Logger.getLogger(App.class.getName()).log(Level.SEVERE, null, ex);
-                }
-
-                /*
-                  Compute duration, throughput of this Mark's step of BM
-                 */
-                long endTime = System.nanoTime();
-                long elapsedTimeNs = endTime - startTime;
-                double sec = (double) elapsedTimeNs / (double) 1000000000;
-                double mbWritten = (double) totalBytesWrittenInMark / (double) MEGABYTE;
-                wMark.setBwMbSec(mbWritten / sec);
-                ui.showMessage("m:" + m + " write IO is " + wMark.getBwMbSecAsString() + " MB/s     "
-                        + "(" + Util.displayString(mbWritten) + "MB written in "
-                        + Util.displayString(sec) + " sec)");
-                App.updateMetrics(wMark);
-                ui.addWriteMark(wMark);
-
-                /*
-                  Let the UI know the interim result described by the current Mark
-                 */
-                ui.updateStats(wMark.getBwMbSec(), wMark.getCumAvg(), wMark.getCumMax());
-
-                // Keep track of statistics to be displayed and persisted after all Marks are done.
-                run.setRunMax(wMark.getCumMax());
-                run.setRunMin(wMark.getCumMin());
-                run.setRunAvg(wMark.getCumAvg());
-                run.setEndTime(new Date());
-            } // END outer loop for specified duration (number of 'marks') for WRITE benchmark
-
-            /*
-              Persist info about the Write BM Run (e.g. into Derby Database)
-             */
-            EntityManager em = EM.getEntityManager();
-            em.getTransaction().begin();
-            em.persist(run);
-            em.getTransaction().commit();
+            executor.runCommand(new WriteCommand(ui, App.numOfMarks, App.numOfBlocks,
+                    App.blockSizeKb, App.blockSequence, startFileNum));
         }
-
-        /*
-          Most benchmarking systems will try to do some cleanup in between 2 benchmark operations to
-          make it more 'fair'. For example a networking benchmark might close and re-open sockets,
-          a memory benchmark might clear or invalidate the Op Systems TLB or other caches, etc.
-         */
 
         // Prompt user to clear disk cache before read test so measurements are valid
         if (App.readTest && App.writeTest && !ui.isCancelled()) {
@@ -187,96 +69,21 @@ public class DiskWorker {
                 App.nextMarkNumber += App.numOfMarks;
                 App.state = App.State.IDLE_STATE;
                 if (App.autoRemoveData) {
-                    Util.deleteDirectory(dataDir);
+                    Util.deleteDirectory(App.dataDir);
                 }
                 ui.benchmarkComplete(true);
                 return true;
             }
         }
 
-        // Same as above, just for Read operations instead of Writes.
         if (App.readTest) {
-            DiskRun run = new DiskRun(DiskRun.IOMode.READ, App.blockSequence);
-            run.setNumMarks(App.numOfMarks);
-            run.setNumBlocks(App.numOfBlocks);
-            run.setBlockSize(App.blockSizeKb);
-            run.setTxSize(App.targetTxSizeKb());
-            run.setDiskInfo(Util.getDiskInfo(dataDir));
-
-            ui.showMessage("disk info: (" + run.getDiskInfo() + ")");
-
-            for (int m = startFileNum; m < startFileNum + App.numOfMarks && !ui.isCancelled(); m++) {
-
-                if (App.multiFile) {
-                    testFile = new File(dataDir.getAbsolutePath()
-                            + File.separator + "testdata" + m + ".jdm");
-                }
-                rMark = new DiskMark(READ);  // starting to keep track of a new benchmark
-                rMark.setMarkNum(m);
-                long startTime = System.nanoTime();
-                long totalBytesReadInMark = 0;
-
-                try {
-                    try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, "r")) {
-                        for (int b = 0; b < numOfBlocks; b++) {
-                            if (App.blockSequence == DiskRun.BlockSequence.RANDOM) {
-                                int rLoc = Util.randInt(0, numOfBlocks - 1);
-                                rAccFile.seek((long) rLoc * blockSize);
-                            } else {
-                                rAccFile.seek((long) b * blockSize);
-                            }
-                            rAccFile.readFully(blockArr, 0, blockSize);
-                            totalBytesReadInMark += blockSize;
-                            rUnitsComplete++;
-                            unitsComplete = rUnitsComplete + wUnitsComplete;
-                            percentComplete = (float) unitsComplete / (float) unitsTotal * 100f;
-                            ui.updateProgress((int) percentComplete);
-                        }
-                    }
-                } catch (FileNotFoundException ex) {
-                    Logger.getLogger(App.class.getName()).log(Level.SEVERE, null, ex);
-                    String emsg = "May not have done Write Benchmarks, so no data available to read."
-                            + ex.getMessage();
-                    ui.showMessage(emsg);
-                    App.nextMarkNumber += App.numOfMarks;
-                    App.state = App.State.IDLE_STATE;
-                    ui.benchmarkComplete(false);
-                    return false;
-                }
-
-                long endTime = System.nanoTime();
-                long elapsedTimeNs = endTime - startTime;
-                double sec = (double) elapsedTimeNs / (double) 1000000000;
-                double mbRead = (double) totalBytesReadInMark / (double) MEGABYTE;
-                rMark.setBwMbSec(mbRead / sec);
-                ui.showMessage("m:" + m + " READ IO is " + rMark.getBwMbSec() + " MB/s    "
-                        + "(MBread " + mbRead + " in " + sec + " sec)");
-                App.updateMetrics(rMark);
-                ui.addReadMark(rMark);
-
-                /*
-                  Let the UI know the interim result described by the current Mark
-                 */
-                ui.updateStats(rMark.getBwMbSec(), rMark.getCumAvg(), rMark.getCumMax());
-
-                run.setRunMax(rMark.getCumMax());
-                run.setRunMin(rMark.getCumMin());
-                run.setRunAvg(rMark.getCumAvg());
-                run.setEndTime(new Date());
-            }
-
-            /*
-              Persist info about the Read BM Run (e.g. into Derby Database)
-             */
-            EntityManager em = EM.getEntityManager();
-            em.getTransaction().begin();
-            em.persist(run);
-            em.getTransaction().commit();
+            success = executor.runCommand(new ReadCommand(ui, App.numOfMarks, App.numOfBlocks,
+                    App.blockSizeKb, App.blockSequence, startFileNum));
         }
 
         App.nextMarkNumber += App.numOfMarks;
         if (App.autoRemoveData) {
-            Util.deleteDirectory(dataDir);
+            Util.deleteDirectory(App.dataDir);
         }
         App.state = App.State.IDLE_STATE;
         ui.benchmarkComplete(success);

--- a/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkCommand.java
@@ -1,0 +1,24 @@
+package edu.touro.mco152.bm.commands;
+
+/**
+ * Command Pattern interface for disk benchmark operations.
+ *
+ * <p>Each concrete command (e.g. {@link WriteCommand}, {@link ReadCommand}) encapsulates
+ * a complete benchmark job — its I/O type, all run parameters, and the UI to report
+ * progress to — so that the job can be handed to any {@link BenchmarkExecutor}
+ * implementation and executed without the caller needing to know the details.
+ *
+ * <p>This separation is what allows commands to eventually be queued, re-run,
+ * executed concurrently, or replayed in different configurations, as described
+ * in the hardware-manufacturer user story.
+ */
+public interface BenchmarkCommand {
+
+    /**
+     * Executes the benchmark job this command represents.
+     *
+     * @return {@code true} if the benchmark completed successfully,
+     *         {@code false} if it was aborted or encountered a fatal error
+     */
+    boolean execute();
+}

--- a/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkExecutor.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkExecutor.java
@@ -1,0 +1,21 @@
+package edu.touro.mco152.bm.commands;
+
+/**
+ * Executor interface for running {@link BenchmarkCommand} instances.
+ *
+ * <p>Decouples the client ({@link edu.touro.mco152.bm.DiskWorker}) from any specific
+ * execution strategy. The first concrete implementation is {@link SimpleExecutor},
+ * which runs commands serially on the calling thread. Future implementations could
+ * run commands concurrently, in priority order, with retry logic, etc. — all without
+ * changing the client code.
+ */
+public interface BenchmarkExecutor {
+
+    /**
+     * Executes the given command according to this executor's strategy.
+     *
+     * @param command the benchmark job to run
+     * @return {@code true} if the command completed successfully, {@code false} otherwise
+     */
+    boolean runCommand(BenchmarkCommand command);
+}

--- a/app/src/main/java/edu/touro/mco152/bm/commands/ReadCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/ReadCommand.java
@@ -1,0 +1,125 @@
+package edu.touro.mco152.bm.commands;
+
+import edu.touro.mco152.bm.App;
+import edu.touro.mco152.bm.BenchmarkUI;
+import edu.touro.mco152.bm.DiskMark;
+import edu.touro.mco152.bm.Util;
+import edu.touro.mco152.bm.persist.DiskRun;
+import edu.touro.mco152.bm.persist.EM;
+import jakarta.persistence.EntityManager;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.RandomAccessFile;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static edu.touro.mco152.bm.App.KILOBYTE;
+import static edu.touro.mco152.bm.App.MEGABYTE;
+import static edu.touro.mco152.bm.DiskMark.MarkType.READ;
+
+/**
+ * Command Pattern implementation for the read benchmark.
+ *
+ * <p>Encapsulates the read I/O loop formerly inside
+ * {@link edu.touro.mco152.bm.DiskWorker}, along with all the run parameters
+ * needed to execute it. The parameters are supplied at construction time so
+ * this command is self-contained and can be handed to any
+ * {@link BenchmarkExecutor} without the executor needing to know about
+ * {@link edu.touro.mco152.bm.App}.
+ */
+public class ReadCommand implements BenchmarkCommand {
+
+    private final BenchmarkUI ui;
+    private final int numOfMarks;
+    private final int numOfBlocks;
+    private final int blockSizeKb;
+    private final DiskRun.BlockSequence blockSequence;
+    private final int startFileNum;
+
+    public ReadCommand(BenchmarkUI ui, int numOfMarks, int numOfBlocks,
+                       int blockSizeKb, DiskRun.BlockSequence blockSequence, int startFileNum) {
+        this.ui = ui;
+        this.numOfMarks = numOfMarks;
+        this.numOfBlocks = numOfBlocks;
+        this.blockSizeKb = blockSizeKb;
+        this.blockSequence = blockSequence;
+        this.startFileNum = startFileNum;
+    }
+
+    @Override
+    public boolean execute() {
+        DiskRun run = new DiskRun(DiskRun.IOMode.READ, blockSequence);
+        run.setNumMarks(numOfMarks);
+        run.setNumBlocks(numOfBlocks);
+        run.setBlockSize(blockSizeKb);
+        run.setTxSize(App.targetTxSizeKb());
+        run.setDiskInfo(Util.getDiskInfo(App.dataDir));
+
+        ui.showMessage("disk info: (" + run.getDiskInfo() + ")");
+
+        int blockSize = blockSizeKb * KILOBYTE;
+        byte[] blockArr = new byte[blockSize];
+
+        int rUnitsComplete = 0;
+        int rUnitsTotal = numOfBlocks * numOfMarks;
+
+        for (int m = startFileNum; m < startFileNum + numOfMarks && !ui.isCancelled(); m++) {
+
+            if (App.multiFile) {
+                App.testFile = new File(App.dataDir.getAbsolutePath()
+                        + File.separator + "testdata" + m + ".jdm");
+            }
+
+            DiskMark rMark = new DiskMark(READ);
+            rMark.setMarkNum(m);
+            long startTime = System.nanoTime();
+            long totalBytesReadInMark = 0;
+
+            try {
+                try (RandomAccessFile rAccFile = new RandomAccessFile(App.testFile, "r")) {
+                    for (int b = 0; b < numOfBlocks; b++) {
+                        if (blockSequence == DiskRun.BlockSequence.RANDOM) {
+                            int rLoc = Util.randInt(0, numOfBlocks - 1);
+                            rAccFile.seek((long) rLoc * blockSize);
+                        } else {
+                            rAccFile.seek((long) b * blockSize);
+                        }
+                        rAccFile.readFully(blockArr, 0, blockSize);
+                        totalBytesReadInMark += blockSize;
+                        rUnitsComplete++;
+                        ui.updateProgress((int) ((float) rUnitsComplete / (float) rUnitsTotal * 100f));
+                    }
+                }
+            } catch (FileNotFoundException ex) {
+                Logger.getLogger(App.class.getName()).log(Level.SEVERE, null, ex);
+                ui.showMessage("May not have done Write Benchmarks, so no data available to read."
+                        + ex.getMessage());
+                return false;
+            } catch (Exception ex) {
+                Logger.getLogger(App.class.getName()).log(Level.SEVERE, null, ex);
+            }
+
+            long endTime = System.nanoTime();
+            double sec = (double) (endTime - startTime) / 1_000_000_000;
+            double mbRead = (double) totalBytesReadInMark / MEGABYTE;
+            rMark.setBwMbSec(mbRead / sec);
+            ui.showMessage("m:" + m + " READ IO is " + rMark.getBwMbSec() + " MB/s    "
+                    + "(MBread " + mbRead + " in " + sec + " sec)");
+            App.updateMetrics(rMark);
+            ui.addReadMark(rMark);
+            ui.updateStats(rMark.getBwMbSec(), rMark.getCumAvg(), rMark.getCumMax());
+
+            run.setRunMax(rMark.getCumMax());
+            run.setRunMin(rMark.getCumMin());
+            run.setRunAvg(rMark.getCumAvg());
+            run.setEndTime(new Date());
+        }
+
+        EntityManager em = EM.getEntityManager();
+        em.getTransaction().begin();
+        em.persist(run);
+        em.getTransaction().commit();
+
+        return true;
+    }
+}

--- a/app/src/main/java/edu/touro/mco152/bm/commands/SimpleExecutor.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/SimpleExecutor.java
@@ -1,0 +1,25 @@
+package edu.touro.mco152.bm.commands;
+
+/**
+ * A serial, single-threaded implementation of {@link BenchmarkExecutor}.
+ *
+ * <p>Runs each {@link BenchmarkCommand} synchronously on the calling thread,
+ * one at a time, in the order submitted. This is the simplest possible execution
+ * strategy and serves as the baseline executor for the Command Pattern refactor.
+ *
+ * <p>Future executors (e.g. concurrent, prioritized, scheduled) can be introduced
+ * by implementing {@link BenchmarkExecutor} without touching any client code.
+ */
+public class SimpleExecutor implements BenchmarkExecutor {
+
+    /**
+     * Runs the given command immediately on the calling thread.
+     *
+     * @param command the benchmark job to execute
+     * @return the result returned by {@link BenchmarkCommand#execute()}
+     */
+    @Override
+    public boolean runCommand(BenchmarkCommand command) {
+        return command.execute();
+    }
+}

--- a/app/src/main/java/edu/touro/mco152/bm/commands/WriteCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/WriteCommand.java
@@ -1,0 +1,133 @@
+package edu.touro.mco152.bm.commands;
+
+import edu.touro.mco152.bm.App;
+import edu.touro.mco152.bm.BenchmarkUI;
+import edu.touro.mco152.bm.DiskMark;
+import edu.touro.mco152.bm.Util;
+import edu.touro.mco152.bm.persist.DiskRun;
+import edu.touro.mco152.bm.persist.EM;
+import jakarta.persistence.EntityManager;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static edu.touro.mco152.bm.App.KILOBYTE;
+import static edu.touro.mco152.bm.App.MEGABYTE;
+import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
+
+/**
+ * Command Pattern implementation for the write benchmark.
+ *
+ * <p>Encapsulates the write I/O loop formerly inside
+ * {@link edu.touro.mco152.bm.DiskWorker}, along with all the run parameters
+ * needed to execute it. The parameters are supplied at construction time so
+ * this command is self-contained and can be handed to any
+ * {@link BenchmarkExecutor} without the executor needing to know about
+ * {@link edu.touro.mco152.bm.App}.
+ */
+public class WriteCommand implements BenchmarkCommand {
+
+    private final BenchmarkUI ui;
+    private final int numOfMarks;
+    private final int numOfBlocks;
+    private final int blockSizeKb;
+    private final DiskRun.BlockSequence blockSequence;
+    private final int startFileNum;
+
+    public WriteCommand(BenchmarkUI ui, int numOfMarks, int numOfBlocks,
+                        int blockSizeKb, DiskRun.BlockSequence blockSequence, int startFileNum) {
+        this.ui = ui;
+        this.numOfMarks = numOfMarks;
+        this.numOfBlocks = numOfBlocks;
+        this.blockSizeKb = blockSizeKb;
+        this.blockSequence = blockSequence;
+        this.startFileNum = startFileNum;
+    }
+
+    @Override
+    public boolean execute() {
+        DiskRun run = new DiskRun(DiskRun.IOMode.WRITE, blockSequence);
+        run.setNumMarks(numOfMarks);
+        run.setNumBlocks(numOfBlocks);
+        run.setBlockSize(blockSizeKb);
+        run.setTxSize(App.targetTxSizeKb());
+        run.setDiskInfo(Util.getDiskInfo(App.dataDir));
+
+        ui.showMessage("disk info: (" + run.getDiskInfo() + ")");
+
+        if (!App.multiFile) {
+            App.testFile = new File(App.dataDir.getAbsolutePath() + File.separator + "testdata.jdm");
+        }
+
+        int blockSize = blockSizeKb * KILOBYTE;
+        byte[] blockArr = new byte[blockSize];
+        for (int b = 0; b < blockArr.length; b++) {
+            if (b % 2 == 0) {
+                blockArr[b] = (byte) 0xFF;
+            }
+        }
+
+        int wUnitsComplete = 0;
+        int wUnitsTotal = numOfBlocks * numOfMarks;
+
+        for (int m = startFileNum; m < startFileNum + numOfMarks && !ui.isCancelled(); m++) {
+
+            if (App.multiFile) {
+                App.testFile = new File(App.dataDir.getAbsolutePath()
+                        + File.separator + "testdata" + m + ".jdm");
+            }
+
+            DiskMark wMark = new DiskMark(WRITE);
+            wMark.setMarkNum(m);
+            long startTime = System.nanoTime();
+            long totalBytesWrittenInMark = 0;
+
+            String mode = App.writeSyncEnable ? "rwd" : "rw";
+
+            try {
+                try (RandomAccessFile rAccFile = new RandomAccessFile(App.testFile, mode)) {
+                    for (int b = 0; b < numOfBlocks; b++) {
+                        if (blockSequence == DiskRun.BlockSequence.RANDOM) {
+                            int rLoc = Util.randInt(0, numOfBlocks - 1);
+                            rAccFile.seek((long) rLoc * blockSize);
+                        } else {
+                            rAccFile.seek((long) b * blockSize);
+                        }
+                        rAccFile.write(blockArr, 0, blockSize);
+                        totalBytesWrittenInMark += blockSize;
+                        wUnitsComplete++;
+                        ui.updateProgress((int) ((float) wUnitsComplete / (float) wUnitsTotal * 100f));
+                    }
+                }
+            } catch (IOException ex) {
+                Logger.getLogger(App.class.getName()).log(Level.SEVERE, null, ex);
+            }
+
+            long endTime = System.nanoTime();
+            double sec = (double) (endTime - startTime) / 1_000_000_000;
+            double mbWritten = (double) totalBytesWrittenInMark / MEGABYTE;
+            wMark.setBwMbSec(mbWritten / sec);
+            ui.showMessage("m:" + m + " write IO is " + wMark.getBwMbSecAsString() + " MB/s     "
+                    + "(" + Util.displayString(mbWritten) + "MB written in "
+                    + Util.displayString(sec) + " sec)");
+            App.updateMetrics(wMark);
+            ui.addWriteMark(wMark);
+            ui.updateStats(wMark.getBwMbSec(), wMark.getCumAvg(), wMark.getCumMax());
+
+            run.setRunMax(wMark.getCumMax());
+
+            run.setRunMin(wMark.getCumMin());
+            run.setRunAvg(wMark.getCumAvg());
+            run.setEndTime(new Date());
+        }
+
+        EntityManager em = EM.getEntityManager();
+        em.getTransaction().begin();
+        em.persist(run);
+        em.getTransaction().commit();
+
+        return true;
+    }
+}

--- a/app/src/test/java/edu/touro/mco152/bm/SimpleExecutorTest.java
+++ b/app/src/test/java/edu/touro/mco152/bm/SimpleExecutorTest.java
@@ -1,0 +1,92 @@
+package edu.touro.mco152.bm;
+
+import edu.touro.mco152.bm.commands.BenchmarkCommand;
+import edu.touro.mco152.bm.commands.BenchmarkExecutor;
+import edu.touro.mco152.bm.commands.ReadCommand;
+import edu.touro.mco152.bm.commands.SimpleExecutor;
+import edu.touro.mco152.bm.commands.WriteCommand;
+import edu.touro.mco152.bm.persist.DiskRun;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the Command Pattern implementation directly — no Swing, no DiskWorker.
+ *
+ * <p>This test class acts as the 'client' described in the Command Pattern:
+ * it constructs a {@link SimpleExecutor} and submits {@link WriteCommand} and
+ * {@link ReadCommand} instances to it directly, verifying that the commands
+ * execute correctly without any involvement of {@link DiskWorker} or the
+ * Swing UI framework.
+ *
+ * <p>Parameters are hardcoded per the assignment specification and are NOT
+ * read from {@link App}.
+ */
+class SimpleExecutorTest {
+
+    // Assignment-specified constants — must not be taken from App
+    private static final int NUM_MARKS = 25;
+    private static final int NUM_BLOCKS = 128;
+    private static final int BLOCK_SIZE_KB = 2048;
+    private static final DiskRun.BlockSequence BLOCK_SEQUENCE = DiskRun.BlockSequence.SEQUENTIAL;
+
+    @BeforeEach
+    void setup() {
+        App.setupDefaultAsPerProperties();
+        App.multiFile = false;
+        App.autoReset = true;
+    }
+
+    /**
+     * Verifies that a WriteCommand submitted to a SimpleExecutor completes
+     * successfully and reports correct progress and throughput — without
+     * using DiskWorker or any Swing component.
+     */
+    @Test
+    void writeBenchmarkCompletesSuccessfully() {
+        NonSwingBenchmarkUI ui = new NonSwingBenchmarkUI();
+        BenchmarkExecutor executor = new SimpleExecutor();
+        BenchmarkCommand write = new WriteCommand(
+                ui, NUM_MARKS, NUM_BLOCKS, BLOCK_SIZE_KB, BLOCK_SEQUENCE, App.nextMarkNumber);
+
+        boolean result = executor.runCommand(write);
+
+        assertTrue(result, "WriteCommand should return true on success");
+        assertFalse(ui.getMessages().isEmpty(), "At least one message should have been recorded");
+        assertEquals(100, ui.getProgress(), "Progress should reach 100%");
+        assertTrue(ui.getLastCumAvg() > 0, "Cumulative average MB/s should be positive");
+        assertTrue(ui.getLastCumMax() > 0, "Cumulative max MB/s should be positive");
+    }
+
+    /**
+     * Verifies that a ReadCommand submitted to a SimpleExecutor completes
+     * successfully after data has been written — without using DiskWorker
+     * or any Swing component.
+     *
+     * <p>A WriteCommand is run first as test setup to ensure data files
+     * exist on disk before the read is attempted.
+     */
+    @Test
+    void readBenchmarkCompletesSuccessfully() {
+        BenchmarkExecutor executor = new SimpleExecutor();
+
+        // Setup: write data so there is something to read
+        NonSwingBenchmarkUI writeUi = new NonSwingBenchmarkUI();
+        executor.runCommand(new WriteCommand(
+                writeUi, NUM_MARKS, NUM_BLOCKS, BLOCK_SIZE_KB, BLOCK_SEQUENCE, App.nextMarkNumber));
+
+        // Execute the read command and assert on its own UI
+        NonSwingBenchmarkUI readUi = new NonSwingBenchmarkUI();
+        BenchmarkCommand read = new ReadCommand(
+                readUi, NUM_MARKS, NUM_BLOCKS, BLOCK_SIZE_KB, BLOCK_SEQUENCE, App.nextMarkNumber);
+
+        boolean result = executor.runCommand(read);
+
+        assertTrue(result, "ReadCommand should return true on success");
+        assertFalse(readUi.getMessages().isEmpty(), "At least one message should have been recorded");
+        assertEquals(100, readUi.getProgress(), "Progress should reach 100%");
+        assertTrue(readUi.getLastCumAvg() > 0, "Cumulative average MB/s should be positive");
+        assertTrue(readUi.getLastCumMax() > 0, "Cumulative max MB/s should be positive");
+    }
+}


### PR DESCRIPTION
## Summary      
  - Extracted the write and read benchmark loops from `DiskWorker` into two
    self-contained command classes (`WriteCommand`, `ReadCommand`) that implement
    a new `BenchmarkCommand` interface
  - Introduced a `BenchmarkExecutor` interface and `SimpleExecutor` - a serial,
    single-threaded executor - so commands can be dispatched without the caller
    knowing their type or implementation details
  - Refactored `DiskWorker` into the Command Pattern "client": it now constructs
    the executor and commands using App configuration, rather than owning the I/O
    logic itself
  - All new classes live in the `commands` package; run parameters
    (numOfMarks, numOfBlocks, blockSizeKb, blockSequence) are supplied at
    construction time and are never read from App inside the commands
  - Added `SimpleExecutorTest` - a new JUnit test class that directly instantiates
    the executor and commands without involving DiskWorker or Swing, acting as the
    Command Pattern client in test form
  - Fixed pre-existing induced bug in `App.targetTxSizeKb()` (used `+` instead of `*`)

  ## Test plan
  - [ ] Run `.\gradlew run` and verify write and read benchmarks still work from the Swing UI
  - [ ] Run `.\gradlew test` and verify all 19 tests pass (18 pass + 1 was the intentional
        bug which is now fixed, so all 19 should pass)
  - [ ] Confirm `SimpleExecutorTest` write and read methods both pass without using
        DiskWorker or any Swing component