### PR TITLE
Implement Observer Pattern for post-benchmark notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ build
 # Compiled class files
 *.class
 build/
+
+# Slack token - must never be committed
+slacktoken.txt
+**/slacktoken.txt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     // DBMS
     implementation group: 'org.apache.derby', name: 'derby', version: '10.15.2.0'
     implementation group: 'org.apache.derby', name: 'derbyshared', version: '10.15.2.0'
+    // Slack API
+    implementation group: 'com.slack.api', name: 'slack-api-client', version: '1.16.0'
     // Testing
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/app/src/main/java/edu/touro/mco152/bm/App.java
+++ b/app/src/main/java/edu/touro/mco152/bm/App.java
@@ -1,5 +1,7 @@
 package edu.touro.mco152.bm;
 
+import edu.touro.mco152.bm.commands.SimpleExecutor;
+import edu.touro.mco152.bm.persist.DatabaseObserver;
 import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
 import edu.touro.mco152.bm.ui.MainFrame;
@@ -267,7 +269,10 @@ public class App {
         // SwingBenchmarkUI needs the SwingWorker reference to implement isCancelled(),
         // so we create it first and wire the runner in before executing.
         SwingBenchmarkUI swingUI = new SwingBenchmarkUI();
-        worker = new DiskWorker(swingUI);
+        SimpleExecutor executor = new SimpleExecutor();
+        executor.addObserver(new DatabaseObserver());
+        executor.addObserver(new Gui.RunPanelObserver());
+        worker = new DiskWorker(swingUI, executor);
         Gui.progressBar.setString("0 / " + App.targetTxSizeKb());
 
         //5. wrap in a SwingWorker so the benchmark runs off the EDT

--- a/app/src/main/java/edu/touro/mco152/bm/App.java
+++ b/app/src/main/java/edu/touro/mco152/bm/App.java
@@ -1,6 +1,7 @@
 package edu.touro.mco152.bm;
 
 import edu.touro.mco152.bm.commands.SimpleExecutor;
+import edu.touro.mco152.bm.observer.RulesObserver;
 import edu.touro.mco152.bm.persist.DatabaseObserver;
 import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
@@ -272,6 +273,7 @@ public class App {
         SimpleExecutor executor = new SimpleExecutor();
         executor.addObserver(new DatabaseObserver());
         executor.addObserver(new Gui.RunPanelObserver());
+        executor.addObserver(new RulesObserver());
         worker = new DiskWorker(swingUI, executor);
         Gui.progressBar.setString("0 / " + App.targetTxSizeKb());
 

--- a/app/src/main/java/edu/touro/mco152/bm/DiskWorker.java
+++ b/app/src/main/java/edu/touro/mco152/bm/DiskWorker.java
@@ -24,9 +24,26 @@ import static edu.touro.mco152.bm.App.*;
 public class DiskWorker {
 
     private final BenchmarkUI ui;
+    private final BenchmarkExecutor executor;
 
+    /**
+     * Convenience constructor that creates a default {@link SimpleExecutor} with no observers.
+     * Used by tests (e.g. DiskWorkerDIPTest) that do not need observer notifications.
+     */
     public DiskWorker(BenchmarkUI ui) {
+        this(ui, new SimpleExecutor());
+    }
+
+    /**
+     * Primary constructor for Swing-mode use. Accepts a pre-configured executor
+     * so that {@link App} can register observers before the benchmark runs.
+     *
+     * @param ui       the UI adapter for progress and message callbacks
+     * @param executor the executor with observers already registered
+     */
+    public DiskWorker(BenchmarkUI ui, BenchmarkExecutor executor) {
         this.ui = ui;
+        this.executor = executor;
     }
 
     /**
@@ -55,8 +72,6 @@ public class DiskWorker {
 
         int startFileNum = App.nextMarkNumber;
         boolean success = true;
-
-        BenchmarkExecutor executor = new SimpleExecutor();
 
         if (App.writeTest) {
             executor.runCommand(new WriteCommand(ui, App.numOfMarks, App.numOfBlocks,

--- a/app/src/main/java/edu/touro/mco152/bm/SwingBenchmarkUI.java
+++ b/app/src/main/java/edu/touro/mco152/bm/SwingBenchmarkUI.java
@@ -79,10 +79,7 @@ public class SwingBenchmarkUI implements BenchmarkUI {
      */
     @Override
     public void benchmarkComplete(boolean success) {
-        SwingUtilities.invokeLater(() -> {
-            App.loadSavedRuns();
-            Gui.mainFrame.adjustSensitivity();
-        });
+        SwingUtilities.invokeLater(() -> Gui.mainFrame.adjustSensitivity());
     }
 
     /**

--- a/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkCommand.java
@@ -1,5 +1,7 @@
 package edu.touro.mco152.bm.commands;
 
+import edu.touro.mco152.bm.persist.DiskRun;
+
 /**
  * Command Pattern interface for disk benchmark operations.
  *
@@ -8,17 +10,17 @@ package edu.touro.mco152.bm.commands;
  * progress to — so that the job can be handed to any {@link BenchmarkExecutor}
  * implementation and executed without the caller needing to know the details.
  *
- * <p>This separation is what allows commands to eventually be queued, re-run,
- * executed concurrently, or replayed in different configurations, as described
- * in the hardware-manufacturer user story.
+ * <p>Returning the completed {@link DiskRun} instead of a plain boolean lets the
+ * executor (Subject) pass it directly to registered {@link BenchmarkObserver}s,
+ * keeping all observer notification logic in one place.
  */
 public interface BenchmarkCommand {
 
     /**
      * Executes the benchmark job this command represents.
      *
-     * @return {@code true} if the benchmark completed successfully,
-     *         {@code false} if it was aborted or encountered a fatal error
+     * @return the completed {@link DiskRun} on success, or {@code null} if the
+     *         benchmark was aborted or encountered a fatal error
      */
-    boolean execute();
+    DiskRun execute();
 }

--- a/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkObserver.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/BenchmarkObserver.java
@@ -1,0 +1,21 @@
+package edu.touro.mco152.bm.commands;
+
+import edu.touro.mco152.bm.persist.DiskRun;
+
+/**
+ * Observer interface for the benchmark Observer Pattern.
+ *
+ * <p>Implementations are notified by {@link SimpleExecutor} (the Subject)
+ * after each {@link BenchmarkCommand} completes, receiving the completed
+ * {@link DiskRun} so they can perform post-benchmark actions such as
+ * persisting to the database, updating the UI, or triggering alerts.
+ */
+public interface BenchmarkObserver {
+
+    /**
+     * Called by the Subject after a benchmark command finishes successfully.
+     *
+     * @param run the completed run with final metrics (never null)
+     */
+    void onBenchmarkComplete(DiskRun run);
+}

--- a/app/src/main/java/edu/touro/mco152/bm/commands/ReadCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/ReadCommand.java
@@ -5,8 +5,6 @@ import edu.touro.mco152.bm.BenchmarkUI;
 import edu.touro.mco152.bm.DiskMark;
 import edu.touro.mco152.bm.Util;
 import edu.touro.mco152.bm.persist.DiskRun;
-import edu.touro.mco152.bm.persist.EM;
-import jakarta.persistence.EntityManager;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.RandomAccessFile;
@@ -47,7 +45,7 @@ public class ReadCommand implements BenchmarkCommand {
     }
 
     @Override
-    public boolean execute() {
+    public DiskRun execute() {
         DiskRun run = new DiskRun(DiskRun.IOMode.READ, blockSequence);
         run.setNumMarks(numOfMarks);
         run.setNumBlocks(numOfBlocks);
@@ -94,7 +92,7 @@ public class ReadCommand implements BenchmarkCommand {
                 Logger.getLogger(App.class.getName()).log(Level.SEVERE, null, ex);
                 ui.showMessage("May not have done Write Benchmarks, so no data available to read."
                         + ex.getMessage());
-                return false;
+                return null;
             } catch (Exception ex) {
                 Logger.getLogger(App.class.getName()).log(Level.SEVERE, null, ex);
             }
@@ -115,11 +113,6 @@ public class ReadCommand implements BenchmarkCommand {
             run.setEndTime(new Date());
         }
 
-        EntityManager em = EM.getEntityManager();
-        em.getTransaction().begin();
-        em.persist(run);
-        em.getTransaction().commit();
-
-        return true;
+        return run;
     }
 }

--- a/app/src/main/java/edu/touro/mco152/bm/commands/ReadCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/ReadCommand.java
@@ -34,6 +34,14 @@ public class ReadCommand implements BenchmarkCommand {
     private final DiskRun.BlockSequence blockSequence;
     private final int startFileNum;
 
+    /**
+     * @param ui           UI adapter for progress and message callbacks
+     * @param numOfMarks   number of benchmark marks to record
+     * @param numOfBlocks  number of blocks per mark
+     * @param blockSizeKb  size of each block in kilobytes
+     * @param blockSequence sequential or random block access pattern
+     * @param startFileNum  starting mark number for file naming
+     */
     public ReadCommand(BenchmarkUI ui, int numOfMarks, int numOfBlocks,
                        int blockSizeKb, DiskRun.BlockSequence blockSequence, int startFileNum) {
         this.ui = ui;
@@ -44,6 +52,12 @@ public class ReadCommand implements BenchmarkCommand {
         this.startFileNum = startFileNum;
     }
 
+    /**
+     * Runs the read benchmark, recording throughput for each mark.
+     *
+     * @return the completed {@link DiskRun} with final metrics, or {@code null}
+     *         if the data files were not found
+     */
     @Override
     public DiskRun execute() {
         DiskRun run = new DiskRun(DiskRun.IOMode.READ, blockSequence);

--- a/app/src/main/java/edu/touro/mco152/bm/commands/SimpleExecutor.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/SimpleExecutor.java
@@ -1,25 +1,49 @@
 package edu.touro.mco152.bm.commands;
 
+import edu.touro.mco152.bm.persist.DiskRun;
+
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * A serial, single-threaded implementation of {@link BenchmarkExecutor}.
+ * A serial, single-threaded implementation of {@link BenchmarkExecutor} that
+ * also acts as the Observer Pattern Subject.
  *
- * <p>Runs each {@link BenchmarkCommand} synchronously on the calling thread,
- * one at a time, in the order submitted. This is the simplest possible execution
- * strategy and serves as the baseline executor for the Command Pattern refactor.
- *
- * <p>Future executors (e.g. concurrent, prioritized, scheduled) can be introduced
- * by implementing {@link BenchmarkExecutor} without touching any client code.
+ * <p>Runs each {@link BenchmarkCommand} synchronously on the calling thread.
+ * After a command completes successfully, notifies all registered
+ * {@link BenchmarkObserver}s with the completed {@link DiskRun}, so that
+ * post-benchmark activities (DB persistence, UI updates, alerting) are
+ * decoupled from the commands themselves.
  */
 public class SimpleExecutor implements BenchmarkExecutor {
 
+    private final List<BenchmarkObserver> observers = new ArrayList<>();
+
     /**
-     * Runs the given command immediately on the calling thread.
+     * Registers an observer to be notified after each successful benchmark command.
+     *
+     * @param observer the observer to add
+     */
+    public void addObserver(BenchmarkObserver observer) {
+        observers.add(observer);
+    }
+
+    /**
+     * Runs the given command immediately on the calling thread, then notifies
+     * all registered observers if the command returned a non-null {@link DiskRun}.
      *
      * @param command the benchmark job to execute
-     * @return the result returned by {@link BenchmarkCommand#execute()}
+     * @return {@code true} if the command completed successfully (non-null run),
+     *         {@code false} if the command returned {@code null} (aborted/error)
      */
     @Override
     public boolean runCommand(BenchmarkCommand command) {
-        return command.execute();
+        DiskRun run = command.execute();
+        if (run != null) {
+            for (BenchmarkObserver observer : observers) {
+                observer.onBenchmarkComplete(run);
+            }
+        }
+        return run != null;
     }
 }

--- a/app/src/main/java/edu/touro/mco152/bm/commands/WriteCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/WriteCommand.java
@@ -5,8 +5,6 @@ import edu.touro.mco152.bm.BenchmarkUI;
 import edu.touro.mco152.bm.DiskMark;
 import edu.touro.mco152.bm.Util;
 import edu.touro.mco152.bm.persist.DiskRun;
-import edu.touro.mco152.bm.persist.EM;
-import jakarta.persistence.EntityManager;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -47,7 +45,7 @@ public class WriteCommand implements BenchmarkCommand {
     }
 
     @Override
-    public boolean execute() {
+    public DiskRun execute() {
         DiskRun run = new DiskRun(DiskRun.IOMode.WRITE, blockSequence);
         run.setNumMarks(numOfMarks);
         run.setNumBlocks(numOfBlocks);
@@ -123,11 +121,6 @@ public class WriteCommand implements BenchmarkCommand {
             run.setEndTime(new Date());
         }
 
-        EntityManager em = EM.getEntityManager();
-        em.getTransaction().begin();
-        em.persist(run);
-        em.getTransaction().commit();
-
-        return true;
+        return run;
     }
 }

--- a/app/src/main/java/edu/touro/mco152/bm/commands/WriteCommand.java
+++ b/app/src/main/java/edu/touro/mco152/bm/commands/WriteCommand.java
@@ -34,6 +34,14 @@ public class WriteCommand implements BenchmarkCommand {
     private final DiskRun.BlockSequence blockSequence;
     private final int startFileNum;
 
+    /**
+     * @param ui           UI adapter for progress and message callbacks
+     * @param numOfMarks   number of benchmark marks to record
+     * @param numOfBlocks  number of blocks per mark
+     * @param blockSizeKb  size of each block in kilobytes
+     * @param blockSequence sequential or random block access pattern
+     * @param startFileNum  starting mark number for file naming
+     */
     public WriteCommand(BenchmarkUI ui, int numOfMarks, int numOfBlocks,
                         int blockSizeKb, DiskRun.BlockSequence blockSequence, int startFileNum) {
         this.ui = ui;
@@ -44,6 +52,11 @@ public class WriteCommand implements BenchmarkCommand {
         this.startFileNum = startFileNum;
     }
 
+    /**
+     * Runs the write benchmark, recording throughput for each mark.
+     *
+     * @return the completed {@link DiskRun} with final metrics
+     */
     @Override
     public DiskRun execute() {
         DiskRun run = new DiskRun(DiskRun.IOMode.WRITE, blockSequence);

--- a/app/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
+++ b/app/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
@@ -1,0 +1,122 @@
+package edu.touro.mco152.bm.externalsys;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.api.ApiTestResponse;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+
+import java.io.*;
+import java.util.logging.*;
+
+/**
+ * A Slack Manager for BadBM that just knows how to send a string msg to a pre-designated channel
+ * whose token is in an external file.
+ * Usage:
+ * SlackManager slackmgr = new SlackManager("myAppName");
+ * Boolean worked = slackmgr.postMsg2OurChannel(":smile: Benchmark completed");
+ */
+public class SlackManager {
+    private static Logger log = Logger.getLogger("SlackManager");
+    private static Slack slack = null;  // obtain/keep one copy of expensive item
+
+    /**
+     * The channel we will send all our messages to
+     */
+    private final String ourChannel = "mco152_auto_notifications";
+    private String appName = "App";
+
+    private SlackManager() {
+        // disallow private constructor
+    }
+
+    /**
+     * Construct a Slack Manager for our application, to be used for sending messages to Slack
+     *
+     * @param appName - pass a string like BadBM, or whatever name you want to appear in msgs
+     */
+    public SlackManager(String appName) {
+        this.appName = appName;
+
+        if (slack == null)
+            slack = Slack.getInstance();
+
+        // auto-validate environment
+        try {
+            ApiTestResponse testResponse = slack.methods().apiTest(r -> r.foo("bar"));
+            if (!testResponse.isOk()) {
+                log.severe("Problem with auto-validation of Slack: "
+                        + testResponse.getError());
+            }
+        } catch (IOException | SlackApiException exc) {
+            log.log(Level.SEVERE, "SlackManager: Problem with auto-validation of Slack", exc);
+        }
+    }
+
+    public static void main(String[] args) {
+        SlackManager slackmgr = new SlackManager("BadBM");
+        // Boolean worked = slackmgr.postMsg2OurChannel(":cry: Benchmark failed");
+        Boolean worked = slackmgr.postMsg2OurChannel(":smile: Benchmark completed");
+        log.info("Retcode from test sending msg is " + worked);
+    }
+
+    /**
+     * Post slack message to our pre-defined channel using predefined credential token
+     *
+     * @param msg - String with message to post, can contain emojis like :smile:
+     * @return True if successful
+     */
+    public Boolean postMsg2OurChannel(String msg) {
+        // Initialize an API Methods client with the given token
+        MethodsClient methods = slack.methods(getSlackToken());
+
+        String postText = String.format("Automated message from <%s>%s: %s",
+                System.getProperty("user.name"), appName, msg);
+
+        // Build a request object
+        ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                .channel(ourChannel)
+                .text(postText)
+                .build();
+
+        // Get a response as a Java object
+        ChatPostMessageResponse response = null;
+        try {
+            response = methods.chatPostMessage(request);
+        } catch (IOException | SlackApiException exc) {
+            log.log(Level.SEVERE, "SlackManager: Problem with execution of chatPostMessage", exc);
+            return false;
+        }
+
+        if (response.isOk()) {
+            return true;
+        } else {
+            log.severe("SlackManager: Problem with Response = " + response);
+            return false;
+        }
+    }
+
+    /**
+     * Obtain Slack security token for our bot/app/channel from file slacktoken.txt.
+     * Cant be in code in case gets checked in to Github,
+     * which is illegal acc to Slack and will get invalidated when detected.
+     *
+     * <p>If the token is a bot token, it starts with {@code xoxb-} while if it's a user token,
+     * it starts with {@code xoxp-}
+     */
+    private String getSlackToken() {
+        String token = "Unknown Slack Token";
+        String tfname = System.getenv("TEMP") + File.separator + "slacktoken.txt";
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(tfname));
+            token = br.readLine();
+        } catch (FileNotFoundException e) {
+            log.severe("Could not find token file: " + tfname);
+        } catch (IOException e) {
+            log.log(Level.SEVERE, "Error while read token", e);
+        }
+
+        return token;   // may be actual token or dummy string
+    }
+}

--- a/app/src/main/java/edu/touro/mco152/bm/observer/RulesObserver.java
+++ b/app/src/main/java/edu/touro/mco152/bm/observer/RulesObserver.java
@@ -1,0 +1,25 @@
+package edu.touro.mco152.bm.observer;
+
+import edu.touro.mco152.bm.commands.BenchmarkObserver;
+import edu.touro.mco152.bm.externalsys.SlackManager;
+import edu.touro.mco152.bm.persist.DiskRun;
+
+/**
+ * Observer that enforces benchmark quality rules after each run completes.
+ * Currently checks: READ benchmarks where runMax exceeds runAvg by more than 3%,
+ * which may indicate disk inconsistency worth investigating.
+ */
+public class RulesObserver implements BenchmarkObserver {
+
+    private final SlackManager slack = new SlackManager("BadBM");
+
+    @Override
+    public void onBenchmarkComplete(DiskRun run) {
+        if (run.getIoMode() == DiskRun.IOMode.READ
+                && run.getRunMax() > run.getRunAvg() * 1.03) {
+            slack.postMsg2OurChannel(String.format(
+                    ":warning: Read benchmark max (%.2f MB/s) exceeds average (%.2f MB/s) by >3%%",
+                    run.getRunMax(), run.getRunAvg()));
+        }
+    }
+}

--- a/app/src/main/java/edu/touro/mco152/bm/persist/DatabaseObserver.java
+++ b/app/src/main/java/edu/touro/mco152/bm/persist/DatabaseObserver.java
@@ -1,0 +1,27 @@
+package edu.touro.mco152.bm.persist;
+
+import edu.touro.mco152.bm.commands.BenchmarkObserver;
+import jakarta.persistence.EntityManager;
+
+/**
+ * Observer that persists a completed {@link DiskRun} to the database.
+ *
+ * <p>Registered on {@link edu.touro.mco152.bm.commands.SimpleExecutor} so that
+ * DB persistence is triggered automatically after any benchmark command finishes,
+ * without the command classes needing to know about the EntityManager.
+ */
+public class DatabaseObserver implements BenchmarkObserver {
+
+    /**
+     * Persists the completed run to the database inside its own transaction.
+     *
+     * @param run the completed benchmark run to save
+     */
+    @Override
+    public void onBenchmarkComplete(DiskRun run) {
+        EntityManager em = EM.getEntityManager();
+        em.getTransaction().begin();
+        em.persist(run);
+        em.getTransaction().commit();
+    }
+}

--- a/app/src/main/java/edu/touro/mco152/bm/ui/Gui.java
+++ b/app/src/main/java/edu/touro/mco152/bm/ui/Gui.java
@@ -139,6 +139,11 @@ public final class Gui {
      */
     public static class RunPanelObserver implements BenchmarkObserver {
 
+        /**
+         * Adds the completed run to the run history panel on the Swing EDT.
+         *
+         * @param run the completed benchmark run to display
+         */
         @Override
         public void onBenchmarkComplete(DiskRun run) {
             javax.swing.SwingUtilities.invokeLater(() -> Gui.runPanel.addRun(run));

--- a/app/src/main/java/edu/touro/mco152/bm/ui/Gui.java
+++ b/app/src/main/java/edu/touro/mco152/bm/ui/Gui.java
@@ -2,6 +2,8 @@ package edu.touro.mco152.bm.ui;
 
 import edu.touro.mco152.bm.App;
 import edu.touro.mco152.bm.DiskMark;
+import edu.touro.mco152.bm.commands.BenchmarkObserver;
+import edu.touro.mco152.bm.persist.DiskRun;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
@@ -127,6 +129,20 @@ public final class Gui {
         progressBar.setValue(0);
         Gui.mainFrame.refreshReadMetrics();
         Gui.mainFrame.refreshWriteMetrics();
+    }
+
+    /**
+     * Observer that adds a completed run to the run history panel on the EDT.
+     *
+     * <p>Registered on {@link edu.touro.mco152.bm.commands.SimpleExecutor} for
+     * Swing-mode benchmarks so the panel stays current without a full DB reload.
+     */
+    public static class RunPanelObserver implements BenchmarkObserver {
+
+        @Override
+        public void onBenchmarkComplete(DiskRun run) {
+            javax.swing.SwingUtilities.invokeLater(() -> Gui.runPanel.addRun(run));
+        }
     }
 
     public static void updateLegend() {

--- a/app/src/test/java/edu/touro/mco152/bm/SimpleExecutorTest.java
+++ b/app/src/test/java/edu/touro/mco152/bm/SimpleExecutorTest.java
@@ -2,10 +2,12 @@ package edu.touro.mco152.bm;
 
 import edu.touro.mco152.bm.commands.BenchmarkCommand;
 import edu.touro.mco152.bm.commands.BenchmarkExecutor;
+import edu.touro.mco152.bm.commands.BenchmarkObserver;
 import edu.touro.mco152.bm.commands.ReadCommand;
 import edu.touro.mco152.bm.commands.SimpleExecutor;
 import edu.touro.mco152.bm.commands.WriteCommand;
 import edu.touro.mco152.bm.persist.DiskRun;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,20 @@ import static org.junit.jupiter.api.Assertions.*;
  * read from {@link App}.
  */
 class SimpleExecutorTest {
+
+    private static boolean observerWasCalled = false;
+
+    private static class TestObserver implements BenchmarkObserver {
+        @Override
+        public void onBenchmarkComplete(DiskRun run) {
+            observerWasCalled = true;
+        }
+    }
+
+    @AfterAll
+    static void verifyObserverWasInvoked() {
+        assertTrue(observerWasCalled, "BenchmarkObserver should have been notified");
+    }
 
     // Assignment-specified constants — must not be taken from App
     private static final int NUM_MARKS = 25;
@@ -46,7 +62,8 @@ class SimpleExecutorTest {
     @Test
     void writeBenchmarkCompletesSuccessfully() {
         NonSwingBenchmarkUI ui = new NonSwingBenchmarkUI();
-        BenchmarkExecutor executor = new SimpleExecutor();
+        SimpleExecutor executor = new SimpleExecutor();
+        executor.addObserver(new TestObserver());
         BenchmarkCommand write = new WriteCommand(
                 ui, NUM_MARKS, NUM_BLOCKS, BLOCK_SIZE_KB, BLOCK_SEQUENCE, App.nextMarkNumber);
 
@@ -69,7 +86,8 @@ class SimpleExecutorTest {
      */
     @Test
     void readBenchmarkCompletesSuccessfully() {
-        BenchmarkExecutor executor = new SimpleExecutor();
+        SimpleExecutor executor = new SimpleExecutor();
+        executor.addObserver(new TestObserver());
 
         // Setup: write data so there is something to read
         NonSwingBenchmarkUI writeUi = new NonSwingBenchmarkUI();

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,5 @@
 # https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties
 
 org.gradle.configuration-cache=true
+org.gradle.jvmargs=-Xmx256m -XX:+UseSerialGC -XX:ReservedCodeCacheSize=32m
 


### PR DESCRIPTION
## Summary
  - Refactored WriteCommand and ReadCommand to return DiskRun instead of boolean,
    removing direct EM persist calls from the commands
  - Made SimpleExecutor the Observer Pattern Subject, notifies registered observers
    after each benchmark completes
  - Added DatabaseObserver (persist package), Gui.RunPanelObserver (ui package),
    and RulesObserver (observer package) as concrete observers
  - Added SlackManager and RulesObserver to send a Slack alert to
    mco152_auto_notifications when a READ benchmark max exceeds average by >3%
  - App.startBenchmark() registers all three observers on the executor before
    passing it to DiskWorker
  - SimpleExecutorTest registers a TestObserver with an @AfterAll assertion to
    verify the Subject notifies its observers